### PR TITLE
[GEN-8081] Fix multisig-ui for the ecosystem multisig

### DIFF
--- a/src/components/Multisig.tsx
+++ b/src/components/Multisig.tsx
@@ -53,11 +53,13 @@ import {
 import { ViewTransactionOnExplorerButton } from "./Notification";
 import * as idl from "../utils/idl";
 import { networks } from "../store/reducer";
-import { useMultisig } from "./MultisigProvider";
+import { useMultisig, MultisigContext } from "./MultisigProvider";
 import { AccountBalanceWallet } from "@material-ui/icons";
 import { mndeTransferInstruction } from "../commands/mnde_transfer";
 import { store } from "../store";
 import { useWallet } from "@solana/wallet-adapter-react";
+import { Program } from "@project-serum/anchor";
+import MultisigIdl from "../idl";
 
 // Seed for generating the idlAddress.
 function seed(): string {
@@ -112,13 +114,41 @@ function NewMultisigButton() {
 }
 
 export function MultisigInstance({ multisig }: { multisig: PublicKey }) {
-  const { multisigClient } = useMultisig();
+  const { multisigClient: baseClient } = useMultisig();
+  // A multisig account can be owned by any deployment of the multisig program
+  // (e.g. the ecosystem multisig lives under a different program than the
+  // treasury/admin multisigs). Resolve the owning program from the account
+  // itself so each instance is read and signed against its real program.
+  const [multisigClient, setMultisigClient] = useState<Program | null>(null);
   const [multisigAccount, setMultisigAccount] = useState<any>(undefined);
   const [transactions, setTransactions] = useState<any>(null);
   const [showSignerDialog, setShowSignerDialog] = useState(false);
   const [showAddTransactionDialog, setShowAddTransactionDialog] = useState(false);
   const [showExecuted, setShowExecuted] = useState(false);
   const [forceRefresh, setForceRefresh] = useState(false);
+  useEffect(() => {
+    if (!baseClient) {
+      setMultisigClient(null);
+      return;
+    }
+    let active = true;
+    baseClient.provider.connection
+      .getAccountInfo(multisig)
+      .then((info) => {
+        if (!active) return;
+        setMultisigClient(
+          info && !info.owner.equals(baseClient.programId)
+            ? new Program(MultisigIdl, info.owner, baseClient.provider)
+            : baseClient
+        );
+      })
+      .catch(() => {
+        if (active) setMultisigClient(baseClient);
+      });
+    return () => {
+      active = false;
+    };
+  }, [baseClient, multisig]);
   useEffect(() => {
     multisigClient?.account.multisig
       .fetch(multisig)
@@ -129,12 +159,12 @@ export function MultisigInstance({ multisig }: { multisig: PublicKey }) {
         console.error(err);
         setMultisigAccount(null);
       });
-  }, [multisig, multisigClient?.account]);
+  }, [multisig, multisigClient]);
   useEffect(() => {
     multisigClient?.account.transaction.all(multisig.toBuffer()).then((txs) => {
       setTransactions(txs);
     });
-  }, [multisigClient?.account.transaction, multisig, forceRefresh]);
+  }, [multisigClient, multisig, forceRefresh]);
   useEffect(() => {
     multisigClient?.account.multisig
       .subscribe(multisig)
@@ -143,6 +173,7 @@ export function MultisigInstance({ multisig }: { multisig: PublicKey }) {
       });
   }, [multisigClient, multisig]);
   return (
+    <MultisigContext.Provider value={{ multisigClient }}>
     <Container fixed maxWidth="md" style={{ marginBottom: "16px" }}>
       <div>
         <Card style={{ marginTop: "24px" }}>
@@ -233,6 +264,7 @@ export function MultisigInstance({ multisig }: { multisig: PublicKey }) {
         />
       )}
     </Container>
+    </MultisigContext.Provider>
   );
 }
 
@@ -989,6 +1021,7 @@ function ChangeThresholdListItemDetails({
   const { multisigClient } = useMultisig();
   // @ts-ignore
   const { enqueueSnackbar } = useSnackbar();
+  const { sendTransaction } = useWallet();
   const changeThreshold = async () => {
     if (!multisigClient?.provider.wallet.publicKey)
       throw Error("Wallet not connected");
@@ -1014,7 +1047,7 @@ function ChangeThresholdListItemDetails({
     ];
     const transaction = new Account();
     const txSize = 1000; // todo
-    const tx = await multisigClient.rpc.createTransaction(
+    const ix = multisigClient.instruction.createTransaction(
       multisigClient.programId,
       accounts,
       data,
@@ -1025,16 +1058,30 @@ function ChangeThresholdListItemDetails({
           proposer: multisigClient.provider.wallet.publicKey,
           rent: SYSVAR_RENT_PUBKEY,
         },
-        signers: [transaction],
-        instructions: [
-          await multisigClient.account.transaction.createInstruction(
-            transaction,
-            // @ts-ignore
-            txSize
-          ),
-        ],
       }
     );
+    const t = new Transaction();
+    t.add(
+      await multisigClient.account.transaction.createInstruction(
+        transaction,
+        // @ts-ignore
+        txSize
+      )
+    );
+    t.add(ix);
+    const {
+      context: { slot: minContextSlot },
+      value: { blockhash, lastValidBlockHeight },
+    } = await multisigClient.provider.connection.getLatestBlockhashAndContext();
+    const tx = await sendTransaction(t, multisigClient.provider.connection, {
+      minContextSlot,
+      signers: [transaction],
+    });
+    await multisigClient.provider.connection.confirmTransaction({
+      blockhash,
+      lastValidBlockHeight,
+      signature: tx,
+    });
     enqueueSnackbar("Transaction created", {
       variant: "success",
       action: <ViewTransactionOnExplorerButton signature={tx} />,
@@ -1062,7 +1109,18 @@ function ChangeThresholdListItemDetails({
         }}
       />
       <div style={{ display: "flex", justifyContent: "flex-end" }}>
-        <Button onClick={() => changeThreshold()}>Change Threshold</Button>
+        <Button
+          onClick={() =>
+            changeThreshold().catch((err) => {
+              enqueueSnackbar(
+                `Unable to create transaction: ${err ? err.toString() : ""}`,
+                { variant: "error" }
+              );
+            })
+          }
+        >
+          Change Threshold
+        </Button>
       </div>
     </div>
   );
@@ -1112,6 +1170,7 @@ function SetOwnersListItemDetails({
   const zeroAddr = PublicKey.default.toString();
   const [participants, setParticipants] = useState([zeroAddr]);
   const { enqueueSnackbar } = useSnackbar();
+  const { sendTransaction } = useWallet();
   const setOwners = async () => {
     if (!multisigClient?.provider.wallet.publicKey)
       throw Error("Wallet not connected");
@@ -1138,7 +1197,7 @@ function SetOwnersListItemDetails({
     ];
     const transaction = new Account();
     const txSize = 5000; // TODO: tighter bound.
-    const tx = await multisigClient.rpc.createTransaction(
+    const ix = multisigClient.instruction.createTransaction(
       multisigClient.programId,
       accounts,
       data,
@@ -1149,16 +1208,30 @@ function SetOwnersListItemDetails({
           proposer: multisigClient.provider.wallet.publicKey,
           rent: SYSVAR_RENT_PUBKEY,
         },
-        signers: [transaction],
-        instructions: [
-          await multisigClient.account.transaction.createInstruction(
-            transaction,
-            // @ts-ignore
-            txSize
-          ),
-        ],
       }
     );
+    const t = new Transaction();
+    t.add(
+      await multisigClient.account.transaction.createInstruction(
+        transaction,
+        // @ts-ignore
+        txSize
+      )
+    );
+    t.add(ix);
+    const {
+      context: { slot: minContextSlot },
+      value: { blockhash, lastValidBlockHeight },
+    } = await multisigClient.provider.connection.getLatestBlockhashAndContext();
+    const tx = await sendTransaction(t, multisigClient.provider.connection, {
+      minContextSlot,
+      signers: [transaction],
+    });
+    await multisigClient.provider.connection.confirmTransaction({
+      blockhash,
+      lastValidBlockHeight,
+      signature: tx,
+    });
     enqueueSnackbar("Transaction created", {
       variant: "success",
       action: <ViewTransactionOnExplorerButton signature={tx} />,
@@ -1207,7 +1280,18 @@ function SetOwnersListItemDetails({
           paddingBottom: "16px",
         }}
       >
-        <Button onClick={() => setOwners()}>Set Owners</Button>
+        <Button
+          onClick={() =>
+            setOwners().catch((err) => {
+              enqueueSnackbar(
+                `Unable to create transaction: ${err ? err.toString() : ""}`,
+                { variant: "error" }
+              );
+            })
+          }
+        >
+          Set Owners
+        </Button>
       </div>
     </div>
   );
@@ -1419,6 +1503,7 @@ function UpgradeIdlListItemDetails({
   const [buffer, setBuffer] = useState<null | string>(null);
 
   const { multisigClient } = useMultisig();
+  const { sendTransaction } = useWallet();
   const { enqueueSnackbar } = useSnackbar();
   const createTransactionAccount = async () => {
     if (!multisigClient?.provider.wallet.publicKey)
@@ -1445,7 +1530,7 @@ function UpgradeIdlListItemDetails({
     ];
     const txSize = 1000; // TODO: tighter bound.
     const transaction = new Account();
-    const tx = await multisigClient.rpc.createTransaction(
+    const ix = multisigClient.instruction.createTransaction(
       programAddr,
       accs,
       data,
@@ -1456,16 +1541,30 @@ function UpgradeIdlListItemDetails({
           proposer: multisigClient.provider.wallet.publicKey,
           rent: SYSVAR_RENT_PUBKEY,
         },
-        signers: [transaction],
-        instructions: [
-          await multisigClient.account.transaction.createInstruction(
-            transaction,
-            // @ts-ignore
-            txSize
-          ),
-        ],
       }
     );
+    const t = new Transaction();
+    t.add(
+      await multisigClient.account.transaction.createInstruction(
+        transaction,
+        // @ts-ignore
+        txSize
+      )
+    );
+    t.add(ix);
+    const {
+      context: { slot: minContextSlot },
+      value: { blockhash, lastValidBlockHeight },
+    } = await multisigClient.provider.connection.getLatestBlockhashAndContext();
+    const tx = await sendTransaction(t, multisigClient.provider.connection, {
+      minContextSlot,
+      signers: [transaction],
+    });
+    await multisigClient.provider.connection.confirmTransaction({
+      blockhash,
+      lastValidBlockHeight,
+      signature: tx,
+    });
     enqueueSnackbar("Transaction created", {
       variant: "success",
       action: <ViewTransactionOnExplorerButton signature={tx} />,
@@ -1504,7 +1603,16 @@ function UpgradeIdlListItemDetails({
           paddingBottom: "16px",
         }}
       >
-        <Button onClick={() => createTransactionAccount()}>
+        <Button
+          onClick={() =>
+            createTransactionAccount().catch((err) => {
+              enqueueSnackbar(
+                `Unable to create transaction: ${err ? err.toString() : ""}`,
+                { variant: "error" }
+              );
+            })
+          }
+        >
           Create upgrade
         </Button>
       </div>
@@ -1559,6 +1667,7 @@ function UpgradeProgramListItemDetails({
   const [buffer, setBuffer] = useState<null | string>(null);
 
   const { multisigClient } = useMultisig();
+  const { sendTransaction } = useWallet();
   const { enqueueSnackbar } = useSnackbar();
   const createTransactionAccount = async () => {
     if (!multisigClient?.provider.wallet.publicKey)
@@ -1602,7 +1711,7 @@ function UpgradeProgramListItemDetails({
     ];
     const txSize = 1000; // TODO: tighter bound.
     const transaction = new Account();
-    const tx = await multisigClient.rpc.createTransaction(
+    const ix = multisigClient.instruction.createTransaction(
       BPF_LOADER_UPGRADEABLE_PID,
       accs,
       data,
@@ -1613,16 +1722,30 @@ function UpgradeProgramListItemDetails({
           proposer: multisigClient.provider.wallet.publicKey,
           rent: SYSVAR_RENT_PUBKEY,
         },
-        signers: [transaction],
-        instructions: [
-          await multisigClient.account.transaction.createInstruction(
-            transaction,
-            // @ts-ignore
-            txSize
-          ),
-        ],
       }
     );
+    const t = new Transaction();
+    t.add(
+      await multisigClient.account.transaction.createInstruction(
+        transaction,
+        // @ts-ignore
+        txSize
+      )
+    );
+    t.add(ix);
+    const {
+      context: { slot: minContextSlot },
+      value: { blockhash, lastValidBlockHeight },
+    } = await multisigClient.provider.connection.getLatestBlockhashAndContext();
+    const tx = await sendTransaction(t, multisigClient.provider.connection, {
+      minContextSlot,
+      signers: [transaction],
+    });
+    await multisigClient.provider.connection.confirmTransaction({
+      blockhash,
+      lastValidBlockHeight,
+      signature: tx,
+    });
     enqueueSnackbar("Transaction created", {
       variant: "success",
       action: <ViewTransactionOnExplorerButton signature={tx} />,
@@ -1661,7 +1784,16 @@ function UpgradeProgramListItemDetails({
           paddingBottom: "16px",
         }}
       >
-        <Button onClick={() => createTransactionAccount()}>
+        <Button
+          onClick={() =>
+            createTransactionAccount().catch((err) => {
+              enqueueSnackbar(
+                `Unable to create transaction: ${err ? err.toString() : ""}`,
+                { variant: "error" }
+              );
+            })
+          }
+        >
           Create upgrade
         </Button>
       </div>

--- a/src/components/Multisig.tsx
+++ b/src/components/Multisig.tsx
@@ -166,11 +166,15 @@ export function MultisigInstance({ multisig }: { multisig: PublicKey }) {
     });
   }, [multisigClient, multisig, forceRefresh]);
   useEffect(() => {
-    multisigClient?.account.multisig
+    if (!multisigClient) return;
+    multisigClient.account.multisig
       .subscribe(multisig)
       .on("change", (account) => {
         setMultisigAccount(account);
       });
+    return () => {
+      multisigClient.account.multisig.unsubscribe(multisig);
+    };
   }, [multisigClient, multisig]);
   return (
     <MultisigContext.Provider value={{ multisigClient }}>
@@ -512,11 +516,15 @@ function TxListItem({
   const [open, setOpen] = useState(false);
   const [txAccount, setTxAccount] = useState(tx.account);
   useEffect(() => {
-    multisigClient?.account.transaction
+    if (!multisigClient) return;
+    multisigClient.account.transaction
       .subscribe(tx.publicKey)
       .on("change", (account) => {
         setTxAccount(account);
       });
+    return () => {
+      multisigClient.account.transaction.unsubscribe(tx.publicKey);
+    };
   }, [multisigClient, multisig, tx.publicKey]);
 
   let txData = fromUint8ArrayToBase64(txAccount.data)

--- a/src/components/MultisigProvider.tsx
+++ b/src/components/MultisigProvider.tsx
@@ -13,7 +13,7 @@ import { State as StoreState } from "../store/reducer";
 import MultisigIdl from "../idl";
 import { useWallet } from "@solana/wallet-adapter-react";
 
-const MultisigContext = React.createContext<MultisigContextValues>({
+export const MultisigContext = React.createContext<MultisigContextValues>({
   multisigClient: null
 });
 


### PR DESCRIPTION
## Summary
Opening a multisig that isn't one of the hardcoded treasury/admin instances —
e.g. the ecosystem multisig `magrsHFQxkkioAy45VWnZnFBBdKVdy2ZiRoRGYT9Wed`
(the program-upgrade authority linked from the liquid-staking DRP) — showed no
past transactions, and creating any proposal silently did nothing (the wallet
never prompted). This fixes both.

## Root causes
1. **Wrong program.** The Anchor `Program` was built from a single hardcoded
   `multisigProgramId` per network (`H88Lf…`, the treasury/admin program). The
   ecosystem multisig is owned by a *different* deployment of the same program
   (`msigmtwz…`), so `getProgramAccounts` returned 0 transactions for it. (The
   header still rendered because Anchor 0.11's `fetch` only checks the 8-byte
   account discriminator, which is identical across both deployments.)
2. **Removed RPC method.** The four "admin" create flows (change threshold, set
   owners, upgrade IDL, upgrade program) went through Anchor 0.11's
   `Provider.send`, which calls the long-removed `getRecentBlockhash` and threw
   *before* `wallet.signTransaction` — so the wallet was never prompted, and
   with no `.catch` the failure was swallowed.

## Changes
- `MultisigInstance` resolves the owning program from
  `getAccountInfo(multisig).owner` and re-provides a matching `Program` via
  context (`MultisigContext` is now exported). Treasury/admin instances are
  unaffected — their owner is that same `H88Lf…` program.
- The four create flows now build the instruction and send via the wallet
  adapter's `sendTransaction` + `getLatestBlockhashAndContext`, matching the
  existing approve/execute/transfer flows. Added error snackbars so failures
  surface instead of failing silently.

## Impact / risk
- The ecosystem multisig (and any multisig under any deployment of this program)
  now loads its transactions and can have proposals created/approved/executed.
- Treasury (`9aN4drM…`) and admin (`7mSA2bg…`) are unchanged — same owning
  program; cost is one extra `getAccountInfo` per page load.
- No dependency or config changes; two source files touched.

## Testing
- `tsc --noEmit` clean; `npm run build` compiles.
- Verified locally with `@testing-library/react` component tests driving the
  real `MultisigInstance` against mainnet (read-only; not committed since they
  hit the network):
  - **Bug A** — with the base client deliberately on the wrong program, the
    multisig's on-chain transactions still load via owner-derivation (the
    pending 3/13 proposal renders; "No transactions found" does not).
  - **Bug B** — the create flow reaches the wallet with a well-formed
    `createTransaction` targeting the correct program; i.e. the
    `getRecentBlockhash` throw is gone. (This assertion fails if the bug is
    present.)
- Not run: a full on-chain create→approve→execute *landing* - to be tested locally or on the deployment directly (with rollback if needed)

## Deploy
No CI deploy. After merge, a maintainer runs `npm run deploy`
(`react-scripts build` + `gh-pages -d build/`) to refresh the GitHub Pages build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCa8xLJ9urY9NSq2S3BjBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCa8xLJ9urY9NSq2S3BjBQ)_