### PR TITLE
[GEN-8081] Pre-set recentBlockhash before wallet sendTransaction

### DIFF
--- a/src/components/Multisig.tsx
+++ b/src/components/Multisig.tsx
@@ -621,6 +621,7 @@ function TxListItem({
       context: { slot: minContextSlot },
       value: { blockhash, lastValidBlockHeight },
     } = await multisigClient.provider.connection.getLatestBlockhashAndContext();
+    t.recentBlockhash = blockhash;
 
     const signature = await sendTransaction(
       t,
@@ -672,6 +673,7 @@ function TxListItem({
       context: { slot: minContextSlot },
       value: { blockhash, lastValidBlockHeight },
     } = await multisigClient.provider.connection.getLatestBlockhashAndContext();
+    t.recentBlockhash = blockhash;
 
     const signature = await sendTransaction(
       t,
@@ -1081,6 +1083,7 @@ function ChangeThresholdListItemDetails({
       context: { slot: minContextSlot },
       value: { blockhash, lastValidBlockHeight },
     } = await multisigClient.provider.connection.getLatestBlockhashAndContext();
+    t.recentBlockhash = blockhash;
     const tx = await sendTransaction(t, multisigClient.provider.connection, {
       minContextSlot,
       signers: [transaction],
@@ -1231,6 +1234,7 @@ function SetOwnersListItemDetails({
       context: { slot: minContextSlot },
       value: { blockhash, lastValidBlockHeight },
     } = await multisigClient.provider.connection.getLatestBlockhashAndContext();
+    t.recentBlockhash = blockhash;
     const tx = await sendTransaction(t, multisigClient.provider.connection, {
       minContextSlot,
       signers: [transaction],
@@ -1397,6 +1401,7 @@ function TransferMNDEListItemDetails({
         context: { slot: minContextSlot },
         value: { blockhash, lastValidBlockHeight },
       } = await multisigClient.provider.connection.getLatestBlockhashAndContext();
+      t.recentBlockhash = blockhash;
 
       const signature = await sendTransaction(
         t,
@@ -1564,6 +1569,7 @@ function UpgradeIdlListItemDetails({
       context: { slot: minContextSlot },
       value: { blockhash, lastValidBlockHeight },
     } = await multisigClient.provider.connection.getLatestBlockhashAndContext();
+    t.recentBlockhash = blockhash;
     const tx = await sendTransaction(t, multisigClient.provider.connection, {
       minContextSlot,
       signers: [transaction],
@@ -1745,6 +1751,7 @@ function UpgradeProgramListItemDetails({
       context: { slot: minContextSlot },
       value: { blockhash, lastValidBlockHeight },
     } = await multisigClient.provider.connection.getLatestBlockhashAndContext();
+    t.recentBlockhash = blockhash;
     const tx = await sendTransaction(t, multisigClient.provider.connection, {
       minContextSlot,
       signers: [transaction],


### PR DESCRIPTION
## Summary
Follow-up to #21, found during deployment testing. Creating a proposal failed with:

> Unable to create transaction: WalletSendTransactionError: failed to get recent blockhash: SolanaJSONRPCError: failed to get recent blockhash: Method not found

## Root cause
#21 routed the create flows through the wallet adapter's `sendTransaction`, but `@solana/wallet-adapter-base@0.7.1`'s `sendTransaction` fills a *missing* `recentBlockhash` via the removed `getRecentBlockhash` RPC (`signer.js:30`):

```js
transaction.recentBlockhash || (transaction.recentBlockhash = (await connection.getRecentBlockhash('finalized')).blockhash);
```

Our flows passed a transaction without a pre-set blockhash, so the adapter hit the dead RPC and wrapped it as `WalletSendTransactionError`. This affected all 7 `sendTransaction` call sites — the four create flows **and** the pre-existing approve/execute/transfer flows (same latent bug).

## Fix
Assign the blockhash we already fetch via `getLatestBlockhashAndContext` to the transaction before calling `sendTransaction`, so the adapter short-circuits and never calls the removed RPC (it already sets `feePayer` itself). 7-line change, one per site.

## Testing
- Reproduced with a component test (the real `MultisigInstance` + a wallet mock faithful to the adapter — i.e. it calls `getRecentBlockhash` when the tx has no blockhash): on the unfixed code the create flow fails with the production symptom; with the fix it succeeds. The owner-derivation test (#21) continues to pass.
- `tsc --noEmit` clean; `npm run build` compiles.

## Deploy
After merge: `npm run deploy` (`react-scripts build` + `gh-pages -d build/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCa8xLJ9urY9NSq2S3BjBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCa8xLJ9urY9NSq2S3BjBQ)_