### PR TITLE
[GEN-8081] Point mainnet RPC at api.mainnet.solana.com (fix rent-exempt 0x91)

### DIFF
--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -54,8 +54,8 @@ export type CommonState = {
 export const networks: Networks = {
   mainnet: {
     // Cluster.
-    label: "marinade.rpcpool.com",
-    url: "https://marinade.rpcpool.com",
+    label: "api.mainnet.solana.com",
+    url: "https://api.mainnet.solana.com",
     explorerClusterSuffix: "",
     multisigProgramId: new PublicKey(
       "H88LfRBiJLZ7wYkHGuwkKTaijfQxexq8JvzUndu7fyjL"
@@ -71,7 +71,7 @@ export const networks: Networks = {
   mainnet1: {
     // Cluster.
     label: "Mainnet Beta",
-    url: "https://marinade.rpcpool.com",
+    url: "https://api.mainnet.solana.com",
     explorerClusterSuffix: "",
     multisigProgramId: new PublicKey(
       "H88LfRBiJLZ7wYkHGuwkKTaijfQxexq8JvzUndu7fyjL"


### PR DESCRIPTION
## Summary
Follow-up found in deployment testing: creating a proposal fails at preflight with `custom program error: 0x91`, even for a wallet that **is** a multisig owner.

## Root cause
`0x91 = 145 = ` Anchor framework **`ConstraintRentExempt`** ("A rent exempt constraint was violated") — *not* `InvalidOwner` (the repo IDL's program errors are 100–106; 145 is a framework code). The serum-multisig `transaction` account is `#[account(zero)]`, which requires rent-exemption.

The proposal account was being created with **0 lamports**: Anchor's `createInstruction` funds it via `getMinimumBalanceForRentExemption(size)`, and web3.js **silently returns `0` when the RPC errors on that method**:
```js
if ('error' in res) { console.warn('Unable to fetch minimum balance for rent exemption'); return 0; }
```
The configured endpoint `marinade.rpcpool.com` errors on `getMinimumBalanceForRentExemption` (confirmed: that exact warning appears in the browser console), so the account was created non-rent-exempt and the program rejected it.

## Fix
Point the mainnet RPC at `https://api.mainnet.solana.com`, which serves the method correctly (verified: returns `7850880` for 1000 bytes). Both the default `mainnet` entry and the `mainnet1` selector entry are updated (and the default's display label).

## Verified
- Decoded a real failing payload: proposer = `8HVYKgq2…` = **owner #6** (so `InvalidOwner` is ruled out), and instruction 0 was `createAccount(space=1000, lamports=0)`.
- Required `Transaction` account size for that proposal (an "Upgrade program" tx: 7 accounts, 4 data bytes, 13-owner signer vec) is **344 bytes**, so the existing `1000` allocation is fine — no size change needed.
- `tsc --noEmit` clean; `npm run build` compiles.

## Deploy
After merge: `npm run deploy` (`react-scripts build` + `gh-pages -d build/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCa8xLJ9urY9NSq2S3BjBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCa8xLJ9urY9NSq2S3BjBQ)_