### PR TITLE
[GEN-8081] Revert mainnet RPC to marinade.rpcpool.com; compute rent locally

### DIFF
--- a/src/components/MultisigProvider.tsx
+++ b/src/components/MultisigProvider.tsx
@@ -37,6 +37,12 @@ export default function MultisigProvider(
       commitment: "recent",
     };
     const connection = new Connection(network.url, opts.preflightCommitment);
+    // marinade.rpcpool.com doesn't serve getMinimumBalanceForRentExemption, and web3.js
+    // silently returns 0 on its error — which creates non-rent-exempt proposal accounts
+    // that the program rejects (ConstraintRentExempt). Compute it from the fixed mainnet
+    // rent params instead: (ACCOUNT_STORAGE_OVERHEAD + dataLen) * lamportsPerByteYear * 2.
+    (connection as any).getMinimumBalanceForRentExemption = async (dataLen: number) =>
+      (128 + dataLen) * 2 * 3480;
     const provider = new Provider(connection, wallet as any, opts);
 
     const multisigClient = new Program(

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -54,8 +54,8 @@ export type CommonState = {
 export const networks: Networks = {
   mainnet: {
     // Cluster.
-    label: "api.mainnet.solana.com",
-    url: "https://api.mainnet.solana.com",
+    label: "marinade.rpcpool.com",
+    url: "https://marinade.rpcpool.com",
     explorerClusterSuffix: "",
     multisigProgramId: new PublicKey(
       "H88LfRBiJLZ7wYkHGuwkKTaijfQxexq8JvzUndu7fyjL"
@@ -71,7 +71,7 @@ export const networks: Networks = {
   mainnet1: {
     // Cluster.
     label: "Mainnet Beta",
-    url: "https://api.mainnet.solana.com",
+    url: "https://marinade.rpcpool.com",
     explorerClusterSuffix: "",
     multisigProgramId: new PublicKey(
       "H88LfRBiJLZ7wYkHGuwkKTaijfQxexq8JvzUndu7fyjL"


### PR DESCRIPTION
## Summary
PR #23 switched mainnet to `api.mainnet.solana.com`, but that public endpoint **403s browser requests** ("Access forbidden") — public RPCs block dApp origins / rate-limit — so the deployed site couldn't load accounts at all.

## Fix
- **Revert** mainnet (and `mainnet1`) RPC to `https://marinade.rpcpool.com`, which is CORS-OK for the site and serves every method the app needs **except** `getMinimumBalanceForRentExemption`.
- **Compute rent-exemption locally** in `MultisigProvider` from the fixed mainnet rent params — `(128 + dataLen) * 2 * 3480` (matches the RPC value exactly, e.g. `7850880` for 1000 bytes) — so proposal accounts are funded rent-exempt and the program stops rejecting them with `ConstraintRentExempt` (`0x91`). This sidesteps the one method that endpoint doesn't serve (which web3.js otherwise swallows, returning `0` lamports).

## Note
Pragmatic fix to unblock now. It hardcodes the standard mainnet rent params (`lamports_per_byte_year=3480`, `exemption_threshold=2`), stable since genesis. The cleaner long-term option is a dedicated, CORS-enabled keyed RPC (Triton-with-token / Helius / QuickNode) that serves all methods — then the local computation can be dropped.

## Verified
- `tsc --noEmit` clean; `npm run build` compiles.
- Rent formula verified against the live RPC: `(128+1000)*2*3480 = 7850880`, matching `getMinimumBalanceForRentExemption(1000)`.

## Deploy
After merge: `npm run deploy` (`react-scripts build` + `gh-pages -d build/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCa8xLJ9urY9NSq2S3BjBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCa8xLJ9urY9NSq2S3BjBQ)_