### PR TITLE
[GEN-8081] Strip minContextSlot from sendTransaction (marinade.rpcpool.com rejects it)

### DIFF
--- a/src/components/MultisigProvider.tsx
+++ b/src/components/MultisigProvider.tsx
@@ -43,6 +43,14 @@ export default function MultisigProvider(
     // rent params instead: (ACCOUNT_STORAGE_OVERHEAD + dataLen) * lamportsPerByteYear * 2.
     (connection as any).getMinimumBalanceForRentExemption = async (dataLen: number) =>
       (128 + dataLen) * 2 * 3480;
+    // marinade.rpcpool.com rejects sendTransaction's minContextSlot param ("Invalid
+    // params"); the wallet adapter forwards it from our send options, so strip it here.
+    const sendRawTransaction = connection.sendRawTransaction.bind(connection);
+    (connection as any).sendRawTransaction = (rawTransaction: any, sendOpts: any = {}) => {
+      const stripped = { ...(sendOpts || {}) };
+      delete stripped.minContextSlot;
+      return sendRawTransaction(rawTransaction, stripped);
+    };
     const provider = new Provider(connection, wallet as any, opts);
 
     const multisigClient = new Program(


### PR DESCRIPTION
## Summary
Follow-up found in deployment testing: with an owner wallet and the rent fix in place, creating a proposal now **passes simulation** (explorer + wallet) but fails at send with:
> Unable to create transaction: WalletSendTransactionError: failed to send transaction: Invalid params

## Root cause
`Invalid params` is a JSON-RPC `-32602` from the `sendTransaction` *request* — not the transaction (which simulates clean). Our create/approve/execute flows call the wallet adapter's `sendTransaction(tx, conn, { minContextSlot, signers })`; the adapter forwards `minContextSlot` to `connection.sendRawTransaction`, and web3.js puts it into the `sendTransaction` RPC config (`index.cjs.js:6789`). **`marinade.rpcpool.com` rejects that param.** `minContextSlot` is only a "don't send to a lagging node" optimization (we got it from `getLatestBlockhashAndContext`) and isn't needed for this single-RPC admin UI.

## Fix
Strip `minContextSlot` from `sendRawTransaction` options in `MultisigProvider` (one place; covers all 7 send sites — create flows + approve/execute/transfer).

## Verified
- Decoded the failing payload: proposer = `8HVYKgq2…` (**an owner**, so past `InvalidOwner`/`0x12c`) and `createAccount lamports=7850880` (rent shim working) — i.e. the tx is valid, consistent with it passing simulation.
- `tsc --noEmit` clean; `npm run build` compiles.

## Deploy
After merge: `npm run deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCa8xLJ9urY9NSq2S3BjBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCa8xLJ9urY9NSq2S3BjBQ)_